### PR TITLE
Add Gmail connection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# python
+# Python Gmail Connector
+
+This repository contains a simple `GmailConnector` class that demonstrates
+how to log in to Gmail using an application password via IMAP.
+
+## Usage
+
+1. Create a `credentials.json` file in the same directory with the following
+   structure:
+
+```json
+{
+    "email": "your_email@gmail.com",
+    "app_password": "your_app_password"
+}
+```
+
+2. Run the connector:
+
+```bash
+python3 gmail_connector.py
+```
+
+The script will attempt to connect to Gmail and print a message on success.
+Remember to generate an app password in your Google account settings if you
+have two-factor authentication enabled.
+

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,4 @@
+{
+    "email": "your_email@gmail.com",
+    "app_password": "your_app_password"
+}

--- a/gmail_connector.py
+++ b/gmail_connector.py
@@ -1,0 +1,46 @@
+import json
+import imaplib
+from typing import Optional
+
+
+class GmailConnector:
+    """Simple connector to Gmail using IMAP and app password."""
+
+    def __init__(self, credentials_path: str = "credentials.json") -> None:
+        self.credentials_path = credentials_path
+        self.email: Optional[str] = None
+        self.password: Optional[str] = None
+        self.imap: Optional[imaplib.IMAP4_SSL] = None
+
+    def load_credentials(self) -> None:
+        """Load email and app password from a JSON file."""
+        with open(self.credentials_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.email = data.get("email")
+        self.password = data.get("app_password")
+
+    def connect(self) -> None:
+        """Connect to Gmail via IMAP using loaded credentials."""
+        if not self.email or not self.password:
+            raise ValueError("Credentials not loaded. Call load_credentials first.")
+        self.imap = imaplib.IMAP4_SSL("imap.gmail.com")
+        self.imap.login(self.email, self.password)
+
+    def logout(self) -> None:
+        """Logout and close IMAP connection."""
+        if self.imap:
+            try:
+                self.imap.logout()
+            finally:
+                self.imap = None
+
+
+if __name__ == "__main__":
+    connector = GmailConnector()
+    connector.load_credentials()
+    try:
+        connector.connect()
+        print("Connected successfully.")
+    finally:
+        connector.logout()
+        print("Logged out.")


### PR DESCRIPTION
## Summary
- add `GmailConnector` class that logs into Gmail via IMAP using an app password
- store credential placeholders in `credentials.json`
- document usage in README

## Testing
- `python3 -m py_compile gmail_connector.py`


------
https://chatgpt.com/codex/tasks/task_e_68743946cc98832389184c69716f5b51